### PR TITLE
Add better logging when an exception is thrown from the language service

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,7 @@ function init(modules: {typescript: typeof ts_module}): ts.server.PluginModule {
             response = errorMsg;
           }
         } catch (e) {
-          response = e.message;
+          response = `${e.stack}\n\n`;
         }
         ipc.server.emit(socket, 'respond', response);
       });


### PR DESCRIPTION
Hopefully this will make it easier to track down BNCH-3601 by giving a stack
trace on the language service side.

Here's what it looks like now:
<img width="851" alt="screen shot 2018-10-20 at 8 54 23 pm" src="https://user-images.githubusercontent.com/211605/47262966-cafe6a80-d4aa-11e8-8a93-3a434b191dab.png">