### PR TITLE
Refactor plugin to work when multiple TS projects are loaded

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,9 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "prettier": "^1.14.0",
-    "typescript": "^3.0.1"
+    "@types/node": "^14.14.21",
+    "prettier": "^2.2.1",
+    "typescript": "^4.1.3"
   },
   "peerDependencies": {
     "typescript": "*"

--- a/src/Protocol.ts
+++ b/src/Protocol.ts
@@ -8,3 +8,4 @@ export interface SimpleDiagnostic {
 
 export const SERVER_ID = 'ts-expose-status-plugin-server';
 export const CALL_EVENT = 'call';
+export const RESPOND_EVENT = 'respond';

--- a/src/TSStatusClient.ts
+++ b/src/TSStatusClient.ts
@@ -1,7 +1,7 @@
 import NodeIPC from 'node-ipc';
 import {resolve} from 'path';
 
-import {CALL_EVENT, SERVER_ID, SimpleDiagnostic} from './Protocol';
+import {CALL_EVENT, RESPOND_EVENT, SERVER_ID, SimpleDiagnostic} from './Protocol';
 
 // The node-ipc types don't export its class types, but we can still hack them out.
 type IPC = InstanceType<typeof NodeIPC.IPC>;
@@ -20,7 +20,7 @@ export default class TSStatusClient {
 
   private constructor(readonly ipc: IPC, readonly connection: NodeIPCClient) {
     // tslint:disable-next-line no-any
-    this.connection.on('respond', (data: any) => {
+    this.connection.on(RESPOND_EVENT, (data: any) => {
       if (this.responseCallback == null) {
         throw new Error('Expected response callback to be set');
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,87 +1,172 @@
 import {IPC} from 'node-ipc';
-import * as ts_module from "typescript/lib/tsserverlibrary";
+import {appendFileSync} from 'fs';
+import {homedir} from 'os';
+import * as ts_module from 'typescript/lib/tsserverlibrary';
 
-import {CALL_EVENT, SERVER_ID, SimpleDiagnostic} from './Protocol';
-import {resolve} from "path";
+import {CALL_EVENT, RESPOND_EVENT, SERVER_ID, SimpleDiagnostic} from './Protocol';
+import {resolve} from 'path';
 
-function init(modules: {typescript: typeof ts_module}): ts.server.PluginModule {
-  const ts = modules.typescript;
-  function create(info: ts.server.PluginCreateInfo): ts_module.LanguageService {
-    const ipc = new IPC();
-    ipc.config.id = SERVER_ID;
-    // We MUST silence logging, or else node-ipc will print to stdout. VSCode talks with the TS
-    // language service over stdin/stdout, so any extraneous messages to stdout will break VSCode's
-    // normal code intelligence features.
-    ipc.config.silent = true;
+const LOG_FILE = `${homedir()}/ts-expose-status-plugin-output.log`;
+const LOGGING_ENABLED = false;
 
-    function log(s: string): void {
-      info.project.projectService.logger.info(s);
-    }
-
-    function logError(s: string): void {
-      info.project.projectService.logger.msg(s, ts.server.Msg.Err);
-    }
-
-    function convertToSimpleDiagnostic(diagnostic: ts.Diagnostic): SimpleDiagnostic {
-      return {
-        filePath: diagnostic.file ? resolve(diagnostic.file.fileName) : null,
-        start: diagnostic.start != null ? diagnostic.start : null,
-        end:
-          diagnostic.start != null && diagnostic.length != null ? diagnostic.start + diagnostic.length : null,
-        message: ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'),
-        code: diagnostic.code,
-      };
-    }
-
-    function getAllErrors(): Array<SimpleDiagnostic> {
-      const program = info.languageService.getProgram();
-      if (!program) {
-        return [];
-      }
-      // Ignore other diagnostic types for now, since they tend to not correspond to typical TS errors.
-      const tsDiagnostics = [...program.getSemanticDiagnostics(), ...program.getSyntacticDiagnostics()];
-      return tsDiagnostics.map((diagnostic) => convertToSimpleDiagnostic(diagnostic));
-    }
-
-    function getErrorsForFiles(filenames: Array<string>): Array<SimpleDiagnostic> {
-      const diagnostics = [];
-      for (const filename of filenames) {
-        // Ignore other diagnostic types for now, since they tend to not correspond to typical TS errors.
-        const tsDiagnostics = [
-          ...info.languageService.getSemanticDiagnostics(filename),
-          ...info.languageService.getSyntacticDiagnostics(filename),
-        ];
-        diagnostics.push(...tsDiagnostics.map((diagnostic) => convertToSimpleDiagnostic(diagnostic)));
-      }
-      return diagnostics;
-    }
-
-    log('Starting ts-expose-status-plugin server');
-    ipc.serve(() => {
-      ipc.server.on(CALL_EVENT, (data, socket) => {
-        log(`Received method call: ${data.method}`);
-        let response;
-        try {
-          if (data.method === 'getAllErrors') {
-            response = getAllErrors();
-          } else if (data.method === 'getErrorsForFiles') {
-            response = getErrorsForFiles(data.filenames);
-          } else {
-            const errorMsg = `Unexpected method: ${data.method}`;
-            logError(errorMsg);
-            response = errorMsg;
-          }
-        } catch (e) {
-          response = `${e.stack}\n\n`;
-        }
-        ipc.server.emit(socket, 'respond', response);
-      });
-    });
-    ipc.server.start();
-
-    return info.languageService;
+/**
+ * Log a message for debugging purposes.
+ *
+ * Rather than using the built-in info.project.projectService.logger.info() logging,
+ * we append to a file in a hard-coded location. This makes it possible to save log
+ * messages before a project has been set up (since the IPC handler is
+ * project-independent) and avoids the need to pass a TSS_LOG env variable.
+ */
+function log(message: string): void {
+  if (LOGGING_ENABLED) {
+    appendFileSync(LOG_FILE, `(pid ${process.pid}) ${new Date().toLocaleString()}: ${message}\n`);
   }
-  return {create};
+}
+
+/**
+ * Typechecking helper for a single project.
+ */
+class ProjectChecker {
+  constructor(readonly ts: typeof ts_module, readonly info: ts.server.PluginCreateInfo) {}
+
+  convertToSimpleDiagnostic(diagnostic: ts.Diagnostic): SimpleDiagnostic {
+    return {
+      filePath: diagnostic.file ? resolve(diagnostic.file.fileName) : null,
+      start: diagnostic.start != null ? diagnostic.start : null,
+      end:
+        diagnostic.start != null && diagnostic.length != null ? diagnostic.start + diagnostic.length : null,
+      message: this.ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'),
+      code: diagnostic.code,
+    };
+  }
+
+  getAllErrors(): Array<SimpleDiagnostic> {
+    const program = this.info.languageService.getProgram();
+    if (!program) {
+      return [];
+    }
+    // Ignore other diagnostic types for now, since they tend to not correspond to typical TS errors.
+    const tsDiagnostics = [...program.getSemanticDiagnostics(), ...program.getSyntacticDiagnostics()];
+    return tsDiagnostics.map((diagnostic) => this.convertToSimpleDiagnostic(diagnostic));
+  }
+
+  getErrorsForFile(filename: string): Array<SimpleDiagnostic> {
+    return [
+      // Ignore other diagnostic types for now, since they tend to not correspond to typical TS errors.
+      ...this.info.languageService.getSemanticDiagnostics(filename),
+      ...this.info.languageService.getSyntacticDiagnostics(filename),
+    ].map((diagnostic) => this.convertToSimpleDiagnostic(diagnostic));
+  }
+
+  fileInProject(filename: string): boolean {
+    return Boolean(this.info.languageService.getProgram()?.getSourceFile(filename));
+  }
+}
+
+/**
+ * Typechecking helper that combines results for all open projects.
+ */
+class MultiProjectChecker {
+  projectCheckers: Array<ProjectChecker> = [];
+
+  registerProject(ts: typeof ts_module, info: ts.server.PluginCreateInfo) {
+    log(`Initializing project ${info.project.projectName}`);
+    this.projectCheckers.push(new ProjectChecker(ts, info));
+  }
+
+  getAllErrors(): Array<SimpleDiagnostic> {
+    return this.projectCheckers.flatMap((checker) => checker.getAllErrors());
+  }
+
+  getErrorsForFiles(filenames: Array<string>): Array<SimpleDiagnostic> {
+    const diagnostics: Array<SimpleDiagnostic> = [];
+    for (const filename of filenames) {
+      let matchedAnyProject = false;
+      // If we have multiple projects open, we don't know which project this
+      // file is in, so check each one for file membership and only check the
+      // one that passes so that we don't throw an exception for the others.
+      // It's also possible that the file is in multiple projects, which may
+      // give different error results (e.g. due to different tsconfig), so
+      // combine results from all projects in that case.
+      for (const projectChecker of this.projectCheckers) {
+        if (projectChecker.fileInProject(filename)) {
+          diagnostics.push(...projectChecker.getErrorsForFile(filename));
+          matchedAnyProject = true;
+        }
+      }
+      if (!matchedAnyProject) {
+        diagnostics.push({
+          filePath: filename,
+          start: null,
+          end: null,
+          message: `\
+File ${filename} was not found in any TypeScript project. \
+Make sure the appropriate TypeScript project(s) are open in your editor.`,
+          code: 20000,
+        });
+      }
+    }
+    return diagnostics;
+  }
+}
+
+let checker = new MultiProjectChecker();
+let isIPCSetUp: boolean = false;
+
+/**
+ * One-time initialization of the IPC listener to communicate with a
+ * TSStatusClient in a different process.
+ */
+function setupIPC() {
+  const ipc = new IPC();
+  ipc.config.id = SERVER_ID;
+  // We MUST silence logging, or else node-ipc will print to stdout. VSCode talks with the TS
+  // language service over stdin/stdout, so any extraneous messages to stdout will break VSCode's
+  // normal code intelligence features.
+  ipc.config.silent = true;
+
+  log(`Starting ts-expose-status-plugin IPC server`);
+  ipc.serve(() => {
+    ipc.server.on(CALL_EVENT, (data, socket) => {
+      log(`Received method call: ${data.method}`);
+      let response;
+      try {
+        if (data.method === 'getAllErrors') {
+          response = checker.getAllErrors();
+        } else if (data.method === 'getErrorsForFiles') {
+          response = checker.getErrorsForFiles(data.filenames);
+        } else {
+          const errorMsg = `Unexpected method: ${data.method}`;
+          log(errorMsg);
+          response = errorMsg;
+        }
+      } catch (e) {
+        response = `${e.stack}\n\n`;
+      }
+      ipc.server.emit(socket, RESPOND_EVENT, response);
+    });
+  });
+  ipc.server.start();
+}
+
+/**
+ * Extension point to initialize this plugin for a TS project. This function is
+ * called once per project but we want to act on all projects at once, so we use
+ * some module-level state to ensure that IPC is only set up once and to register
+ * all projects that have been loaded.
+ */
+function init(modules: {typescript: typeof ts_module}): ts.server.PluginModule {
+  if (!isIPCSetUp) {
+    setupIPC();
+    isIPCSetUp = true;
+  }
+  const ts = modules.typescript;
+  return {
+    create(info: ts.server.PluginCreateInfo): ts_module.LanguageService {
+      checker.registerProject(ts, info);
+      return info.languageService;
+    },
+  };
 }
 
 export = init;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "downlevelIteration": true,
     "esModuleInterop": true,
     "importHelpers": true,
-    "lib": ["es2017", "DOM"],
+    "lib": ["es2020"],
     "module": "commonjs",
     "noEmitHelpers": true,
     "noImplicitAny": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,11 @@
   version "10.5.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.5.4.tgz#6eccc158504357d1da91434d75e86acde94bb10b"
 
+"@types/node@^14.14.21":
+  version "14.14.21"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.21.tgz#d934aacc22424fe9622ebf6857370c052eae464e"
+  integrity sha512-cHYfKsnwllYhjOzuC5q1VpguABBeecUp24yFluHpn/BQaVxB1CuQ1FSRZCzrPxrkIfWISXV2LbeoBthLWg0+0A==
+
 easy-stack@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/easy-stack/-/easy-stack-1.0.0.tgz#12c91b3085a37f0baa336e9486eac4bf94e3e788"
@@ -38,14 +43,16 @@ node-ipc@^9.1.1:
     js-message "1.0.5"
     js-queue "2.0.0"
 
-prettier@^1.14.0:
-  version "1.14.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.0.tgz#847c235522035fd988100f1f43cf20a7d24f9372"
+prettier@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
+  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
 
 tslib@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
 
-typescript@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.1.tgz#43738f29585d3a87575520a4b93ab6026ef11fdb"
+typescript@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.3.tgz#519d582bd94cba0cf8934c7d8e8467e473f53bb7"
+  integrity sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==


### PR DESCRIPTION
This is pretty much a rewrite of the plugin to better handle situations where a
single editor is working with files from multiple TS projects. Previously, the
init and create functions were being called once per project, so when loading
the second project we'd register a new IPC listener and clobber the old one, so
any file requests received from the wrong project would get a "file not found"
error and crash the TSStatusClient.

After this rewrite, we bookkeep the open projects and register a single IPC
listener that tries each project and combines the results. I also refactored it
into two classes and smaller functions and changed the logging system to just
append to a hard-coded file.

This plugin is still non-ideal for multi-project use cases because if you happen
to have the projects open in different editors, they'll run in different TS
server processes and the second listener will clobber the first. There doesn't
seem to be an obvious way to configure node-ipc to have multiple servers and get
a response from each of them, but I'm sure there's a way to make it work.

Test Plan:
Enable logging and confirm
Tweak the code so that the "not found in any project" message always appears and
make sure it that it looks reasonable.
Try using `bin/dev check` in the aurelia project with PyCharm and with VSCode
and ensure that both now work.